### PR TITLE
Adds optional, but default whitespace stripping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - 'v*.*.*'
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout
@@ -20,8 +20,11 @@ jobs:
           go-version: 1.17
 
       - name: Run linting and testing
-        run: make
-
+        run: |
+          #!/bin/sh
+          set -eux
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          make
       # https://github.com/goreleaser/goreleaser-action
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
-name: release
+name: test
 on:
+  pull_request:
   push:
+    branches:
+      - "main"
     tags:
       - 'v*.*.*'
 jobs:
@@ -18,15 +21,6 @@ jobs:
         uses: actions/setup-go@v3.2.0
         with:
           go-version: 1.17
-
+      
       - name: Run linting and testing
         run: make
-
-      # https://github.com/goreleaser/goreleaser-action
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - 'v*.*.*'
 jobs:
-  goreleaser:
+  test:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout
@@ -20,7 +20,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3.2.0
         with:
-          go-version: 1.17
+          go-version: 1.16
       
       - name: Run linting and testing
-        run: make
+        run: |
+          #!/bin/sh
+          set -eux
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          make

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-PLATFORMS := darwin-amd64 linux-amd64 linux-arm
+PLATFORMS := darwin-amd64 darwin-arm64 linux-amd64 linux-arm
 TARGETS := $(PLATFORMS:%=build/%/mdtablefmt)
-.PHONY: build clean lint
+.PHONY: build test clean lint
 
-build: lint $(TARGETS)
+build: lint test $(TARGETS)
 
 clean:
 	@echo '==> Cleaning'
@@ -12,9 +12,11 @@ lint: *.go
 	@echo '==> Linting'
 	go fmt
 	go vet
-	golint
 	staticcheck
 
+test: *.go
+	@echo '==> Testing'
+	go test
 
 build/%: *.go
 	@echo '==> Building $@'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # mdtablefmt
 
-utility for reformatting markdown tables
+command-line utility for reformatting markdown tables
 
-It reads the text for a single markdown table from the standard input and prints the table to standard output with the columns of the proper width and alignment.
+`mdtablefmt` reads the text for a single markdown table from the standard input and prints the table to the standard output with the columns properly aligned.
 
 ## Example
 
@@ -31,19 +31,81 @@ Virtualization in container support | no | yes
 ### Output
 
 ```markdown
-                               stat |       before       |       after     
+                               stat |       before       |       after
 ----------------------------------: | :----------------: | :--------------:
-                             Memory |        8GiB        |      127GiB     
-                               CPUs |          4         |        16       
-                      Storage space |        423 G       |       31 T      
-                     Storage driver |        aufs        |     overlay2    
+                             Memory |        8GiB        |      127GiB
+                               CPUs |          4         |        16
+                      Storage space |        423 G       |       31 T
+                     Storage driver |        aufs        |     overlay2
                                  OS | Debian GNU/Linux 8 | Ubuntu 20.04 LTS
-                     Docker version |     17.05.0-ce     |    19.03.9-ce   
-               Memory limit support |         no         |        yes      
-                 Swap limit support |         no         |        yes      
-        Kernel memory limit support |         no         |        yes      
-           OOM kill disable support |         no         |        yes      
-              CPU cfs quota support |         no         |        yes      
-             CPU cfs period support |         no         |        yes      
-Virtualization in container support |         no         |        yes      
+                     Docker version |     17.05.0-ce     |    19.03.9-ce
+               Memory limit support |         no         |        yes
+                 Swap limit support |         no         |        yes
+        Kernel memory limit support |         no         |        yes
+           OOM kill disable support |         no         |        yes
+              CPU cfs quota support |         no         |        yes
+             CPU cfs period support |         no         |        yes
+Virtualization in container support |         no         |        yes
+```
+
+The output normally has trailing spaces stripped, if you want to retain trailing spaces you can use the `-no-strip` flag. The following shows the difference in output (**with spaces converted to `.` here for better visibility**).
+
+Without `-no-strip`:
+
+```
+...............................stat.|.......before.......|.......after
+----------------------------------:.|.:----------------:.|.:--------------:
+.............................Memory.|........8GiB........|......127GiB
+...............................CPUs.|..........4.........|........16
+......................Storage.space.|........423.G.......|.......31.T
+.....................Storage.driver.|........aufs........|.....overlay2
+.................................OS.|.Debian.GNU/Linux.8.|.Ubuntu.20.04.LTS
+.....................Docker.version.|.....17.05.0-ce.....|....19.03.9-ce
+...............Memory.limit.support.|.........no.........|........yes
+.................Swap.limit.support.|.........no.........|........yes
+........Kernel.memory.limit.support.|.........no.........|........yes
+...........OOM.kill.disable.support.|.........no.........|........yes
+..............CPU.cfs.quota.support.|.........no.........|........yes
+.............CPU.cfs.period.support.|.........no.........|........yes
+Virtualization.in.container.support.|.........no.........|........yes
+```
+
+With `-no-strip`:
+
+```
+...............................stat.|.......before.......|.......after.....
+----------------------------------:.|.:----------------:.|.:--------------:
+.............................Memory.|........8GiB........|......127GiB.....
+...............................CPUs.|..........4.........|........16.......
+......................Storage.space.|........423.G.......|.......31.T......
+.....................Storage.driver.|........aufs........|.....overlay2....
+.................................OS.|.Debian.GNU/Linux.8.|.Ubuntu.20.04.LTS
+.....................Docker.version.|.....17.05.0-ce.....|....19.03.9-ce...
+...............Memory.limit.support.|.........no.........|........yes......
+.................Swap.limit.support.|.........no.........|........yes......
+........Kernel.memory.limit.support.|.........no.........|........yes......
+...........OOM.kill.disable.support.|.........no.........|........yes......
+..............CPU.cfs.quota.support.|.........no.........|........yes......
+.............CPU.cfs.period.support.|.........no.........|........yes......
+Virtualization.in.container.support.|.........no.........|........yes......
+```
+
+
+## Usage
+
+The program prints the following text when invoked with the -h or --help flag:
+
+```
+usage: mdtablefmt
+
+utility for formatting Markdown tables; reads valid markdown table data on the
+standard input and writes a properly spaced and padded version on the standard
+output
+
+For more information, visit the source code repository:
+https://github.com/backplane/mdtablefmt
+
+  -no-strip
+    	fully pad the rightmost output column instead of stripping trailing whitespace
+
 ```

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 )
@@ -26,6 +27,19 @@ type MarkdownTable struct {
 	Rows             [][]string
 }
 
+var noStrip bool
+
+const helpText = `usage: %s
+
+utility for formatting Markdown tables; reads valid markdown table data on the
+standard input and writes a properly spaced and padded version on the standard
+output
+
+For more information, visit the source code repository:
+https://github.com/backplane/mdtablefmt
+
+`
+
 // NewMarkdownTable is the constructor for MarkdownTable
 func NewMarkdownTable() *MarkdownTable {
 	headings := make([]string, 0)
@@ -40,8 +54,16 @@ func NewMarkdownTable() *MarkdownTable {
 	}
 }
 
-func main() {
+func init() {
+	flag.BoolVar(&noStrip, "no-strip", false, "fully pad the rightmost output column instead of stripping trailing whitespace")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, helpText, os.Args[0])
+		flag.PrintDefaults()
+	}
 
+}
+
+func main() {
 	flag.Parse()
 
 	// Load a table from STDIN
@@ -51,5 +73,5 @@ func main() {
 	}
 
 	// Print the table back out (reformatted)
-	PrintMarkdownTable(table)
+	PrintMarkdownTable(os.Stdout, table, noStrip)
 }

--- a/printing_test.go
+++ b/printing_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+const input string = `
+stat | before | after
+---: | :-----: | :------:
+Memory | 8GiB | 127GiB
+CPUs | 4 | 16
+Storage space | 423 G | 31 T
+Storage driver | aufs | overlay2
+OS | Debian GNU/Linux 8 | Ubuntu 20.04 LTS
+Docker version | 17.05.0-ce | 19.03.9-ce
+Memory limit support | no | yes
+Swap limit support | no | yes
+Kernel memory limit support | no | yes
+OOM kill disable support | no | yes
+CPU cfs quota support | no | yes
+CPU cfs period support | no | yes
+Virtualization in container support | no | yes
+`
+
+const expected_output_padded string = `                               stat |       before       |       after     
+----------------------------------: | :----------------: | :--------------:
+                             Memory |        8GiB        |      127GiB     
+                               CPUs |          4         |        16       
+                      Storage space |        423 G       |       31 T      
+                     Storage driver |        aufs        |     overlay2    
+                                 OS | Debian GNU/Linux 8 | Ubuntu 20.04 LTS
+                     Docker version |     17.05.0-ce     |    19.03.9-ce   
+               Memory limit support |         no         |        yes      
+                 Swap limit support |         no         |        yes      
+        Kernel memory limit support |         no         |        yes      
+           OOM kill disable support |         no         |        yes      
+              CPU cfs quota support |         no         |        yes      
+             CPU cfs period support |         no         |        yes      
+Virtualization in container support |         no         |        yes      
+`
+
+const expected_output_stripped string = `                               stat |       before       |       after
+----------------------------------: | :----------------: | :--------------:
+                             Memory |        8GiB        |      127GiB
+                               CPUs |          4         |        16
+                      Storage space |        423 G       |       31 T
+                     Storage driver |        aufs        |     overlay2
+                                 OS | Debian GNU/Linux 8 | Ubuntu 20.04 LTS
+                     Docker version |     17.05.0-ce     |    19.03.9-ce
+               Memory limit support |         no         |        yes
+                 Swap limit support |         no         |        yes
+        Kernel memory limit support |         no         |        yes
+           OOM kill disable support |         no         |        yes
+              CPU cfs quota support |         no         |        yes
+             CPU cfs period support |         no         |        yes
+Virtualization in container support |         no         |        yes
+`
+
+// TestHelloName calls greetings.Hello with a name, checking
+// for a valid return value.
+func TestPrintMarkdownTable(t *testing.T) {
+	want := expected_output_stripped
+
+	table, err := ParseMarkdownTable(strings.NewReader(input))
+	if err != nil {
+		log.Fatalf("failed to parse markdown table from test input string, error: %s", err)
+	}
+	buf := new(bytes.Buffer)
+	PrintMarkdownTable(buf, table, false)
+	have := buf.String()
+
+	if have != want {
+		t.Fatalf("PrintMarkdownTable failed; have:\nSTART\n%s\nEND\n, want:\nSTART\n%s\nEND\n", have, want)
+	}
+}
+
+func TestPrintMarkdownTableUnstripped(t *testing.T) {
+	want := expected_output_padded
+
+	table, err := ParseMarkdownTable(strings.NewReader(input))
+	if err != nil {
+		log.Fatalf("failed to parse markdown table from test input string, error: %s", err)
+	}
+	buf := new(bytes.Buffer)
+	PrintMarkdownTable(buf, table, true)
+	have := buf.String()
+
+	if have != want {
+		t.Fatalf("PrintMarkdownTable failed; have:\nSTART\n%s\nEND\n, want:\nSTART\n%s\nEND\n", have, want)
+	}
+}


### PR DESCRIPTION
This pr causes the output to have trailing whitespace stripped by default, but this is controllable with a new cli option. It also adds some basic tests and improves the documentation.